### PR TITLE
chore: update uv.lock to dlio_benchmark f58903c (PRs #9 and #10)

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -245,7 +245,7 @@ wheels = [
 [[package]]
 name = "dlio-benchmark"
 version = "3.0.0"
-source = { git = "https://github.com/russfellows/dlio_benchmark.git?branch=main#0a1b3c553c54671bac230a98a2a11e92ebb68b36" }
+source = { git = "https://github.com/russfellows/dlio_benchmark.git?branch=main#f58903c1b2d6251c3662f8f735f40d0c3bf3b49e" }
 dependencies = [
     { name = "dgen-py" },
     { name = "h5py" },


### PR DESCRIPTION
UPdated uv.lock to point to my latest version of dlio_benchmark.

My latest dlio_benchmark now incldues all PRs in main on the MLCommons fork, and also includes the new, in process PR#10 from Wolfgang to speedup Parquet generation.  